### PR TITLE
ci: explicitly specify token for codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
       - uses: codecov/codecov-action@v4
         with:
           file: lcov.info
+          token: ${{ secrets.CODECOV_TOKEN }}
       - uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Explicitly specify the codecov token to be used (i.e., CODECOV_TOKEN), given that the latest v4 release of the codecov action requires it to be able to generate coverage reports.
