### PR TITLE
Add support for direct application of a piecewise definition

### DIFF
--- a/src/parse.jl
+++ b/src/parse.jl
@@ -112,6 +112,9 @@ function parse_apply(node)
         error("calling parse_apply requires the name of the element to be `apply`")
     elms = elements(node)
     cs = parse_node.(elms[2:end])
+    if elms[1].name == "piecewise"
+        return parse_piecewise(elms[1])
+    end
     applymap[elms[1].name](cs)
 end
 


### PR DESCRIPTION
## Checklist

- [ ] Appropriate tests were added
- [ ] Any code changes were done in a way that does not break public API
- [ ] All documentation related to code changes were updated
- [ ] The new code follows the
  [contributor guidelines](https://github.com/SciML/.github/blob/master/CONTRIBUTING.md), in particular the [SciML Style Guide](https://github.com/SciML/SciMLStyle) and
  [COLPRAC](https://github.com/SciML/COLPRAC).
- [ ] Any new documentation only uses public API
  
## Additional context

A bare piecewise in an apply would fail to parse since its definition isn't in the applymap. This just special cases that out so that we parse it properly.
